### PR TITLE
feat: spawn python scripts

### DIFF
--- a/public/app/listeners/executePythonScript.js
+++ b/public/app/listeners/executePythonScript.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const { spawn } = require('child_process');
+const logger = require('../logger');
+
+const executePythonScript = () => {
+  logger.debug('executing a python file');
+  logger.debug(__dirname);
+
+  const process = spawn('python', [
+    path.resolve(__dirname, '../../python.py'), // todo: this file should be a parameter
+    'hello',
+  ]);
+
+  process.stdout.on('data', (chunk) => {
+    const textChunk = chunk.toString('utf8'); // buffer to string
+
+    logger.debug(textChunk);
+  });
+};
+
+module.exports = executePythonScript;

--- a/public/app/listeners/index.js
+++ b/public/app/listeners/index.js
@@ -1,0 +1,5 @@
+const executePythonScript = require('./executePythonScript');
+
+module.exports = {
+  executePythonScript,
+};

--- a/public/electron.js
+++ b/public/electron.js
@@ -17,6 +17,7 @@ const {
 } = require('./app/config/config');
 const isMac = require('./app/utils/isMac');
 const env = require('./env.json');
+const { executePythonScript } = require('./app/listeners');
 
 // add keys to process
 Object.keys(env).forEach((key) => {
@@ -220,6 +221,8 @@ const generateMenu = () => {
 app.on('ready', async () => {
   createWindow();
   generateMenu();
+
+  executePythonScript();
 });
 
 app.on('activate', () => {

--- a/public/python.py
+++ b/public/python.py
@@ -1,0 +1,6 @@
+# this is a dummy python script
+import sys
+
+data = "this began life in python " + sys.argv[1]
+print(data)
+sys.stdout.flush()


### PR DESCRIPTION
This PR contains an example on how to run python scripts. 

The script is spawned at the launching of the app.

No button triggers the action yet.

ref #10 