### PR TITLE
feat: adjust how dataset sizes are displayed in tables

### DIFF
--- a/src/components/Datasets.js
+++ b/src/components/Datasets.js
@@ -22,6 +22,7 @@ import { DEFAULT_LOCALE_DATE } from '../config/constants';
 import { getDatasets, deleteDataset } from '../actions';
 import { buildDatasetPath, LOAD_DATASET_PATH } from '../config/paths';
 import Table from './common/Table';
+import { formatFileSize } from '../utils/formatting';
 
 const styles = (theme) => ({
   addButton: {
@@ -159,7 +160,7 @@ class Datasets extends Component {
         createdAt,
         description = '',
       } = dataset;
-      const sizeString = size ? `${size}${t('KB')}` : t('Unknown');
+      const sizeString = size ? `${formatFileSize(size)}` : t('Unknown');
       const createdAtString = createdAt
         ? new Date(createdAt).toLocaleString(DEFAULT_LOCALE_DATE)
         : t('Unknown');

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -21,6 +21,7 @@ import { DEFAULT_LOCALE_DATE } from '../config/constants';
 import { getResults, deleteResult, getAlgorithms } from '../actions';
 import { buildResultPath } from '../config/paths';
 import Table from './common/Table';
+import { formatFileSize } from '../utils/formatting';
 
 const styles = (theme) => ({
   addButton: {
@@ -162,7 +163,7 @@ class Results extends Component {
         description = '',
       } = result;
 
-      const sizeString = size ? `${size}${t('KB')}` : t('Unknown');
+      const sizeString = size ? `${formatFileSize(size)}` : t('Unknown');
       const createdAtString = createdAt
         ? new Date(createdAt).toLocaleString(DEFAULT_LOCALE_DATE)
         : t('Unknown');

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,0 +1,14 @@
+// takes fileSize in KBs with 3 decimals places, and formats them
+// if size < 100, display size in KBs to 2dps, e.g. 19.432 --> '19.43KB'
+// if size <= 999.499, display size in KBs rounded to nearest integer, e.g. 431.855 --> '432KB'
+// if size > 999.499, display size in MBs to 2ps, e.g. 12521.482 --> 12.52MB'
+// eslint-disable-next-line import/prefer-default-export
+export const formatFileSize = (sizeInKb) => {
+  if (sizeInKb < 100) {
+    return `${sizeInKb.toFixed(2)}KB`;
+  }
+  if (sizeInKb <= 999.499) {
+    return `${Math.round(sizeInKb)}KB`;
+  }
+  return `${(Math.round(sizeInKb) / 1000).toFixed(2)}MB`;
+};

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,14 +1,14 @@
 // takes fileSize in KBs with 3 decimals places, and formats them
-// if size < 100, display size in KBs to 2dps, e.g. 19.432 --> '19.43KB'
-// if size <= 999.499, display size in KBs rounded to nearest integer, e.g. 431.855 --> '432KB'
-// if size > 999.499, display size in MBs to 2ps, e.g. 12521.482 --> 12.52MB'
 // eslint-disable-next-line import/prefer-default-export
 export const formatFileSize = (sizeInKb) => {
+  // if size < 100, display size in KBs to 2dps, e.g. 19.432 --> '19.43KB'
   if (sizeInKb < 100) {
     return `${sizeInKb.toFixed(2)}KB`;
   }
-  if (sizeInKb <= 999.499) {
+  // if size < 999.5, display size in KBs rounded to nearest integer, e.g. 431.855 --> '432KB'
+  if (sizeInKb < 999.5) {
     return `${Math.round(sizeInKb)}KB`;
   }
+  // if size >= 999.5, display size in MBs to 2dps, e.g. 12521.482 --> 12.52MB'
   return `${(Math.round(sizeInKb) / 1000).toFixed(2)}MB`;
 };


### PR DESCRIPTION
a small PR to adjust how dataset sizes are displayed in our tables. it now looks like this:

![Screen Shot 2020-10-23 at 5 16 49 PM](https://user-images.githubusercontent.com/19311953/97022001-e26a0580-1553-11eb-9fc6-d1f050c52e47.png)
