### PR TITLE
feat: add standard visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You will also need to create a file called `.env.local` with the following conte
 ```dotenv
 GH_TOKEN=
 BROWSER=none
+REACT_APP_GOOGLE_KEY=
 ```
 
 The `GH_TOKEN` environment variable is only used for releasing new versions of the Graasp Desktop

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.4",
     "fs-extra": "9.0.1",
+    "google-map-react": "2.1.9",
     "history": "5.0.0",
     "i18next": "19.6.3",
     "immutable": "4.0.0-rc.12",
@@ -48,10 +49,14 @@
     "react-redux-toastr": "7.6.5",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
+    "react-select": "3.1.0",
+    "recharts": "1.8.5",
     "redux": "4.0.5",
     "redux-devtools-extension": "2.13.8",
     "redux-promise": "0.6.0",
-    "redux-thunk": "2.3.0"
+    "redux-thunk": "2.3.0",
+    "supercluster": "7.1.0",
+    "use-supercluster": "0.2.9"
   },
   "devDependencies": {
     "@babel/cli": "7.8.4",

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import {
   EXECUTIONS_PATH,
   EDIT_ALGORITHM_PATH,
   ADD_ALGORITHM_PATH,
+  VISUALIZATIONS_PATH,
 } from './config/paths';
 import theme from './theme';
 import LoadDatasetModal from './components/LoadDatasetModal';
@@ -31,6 +32,7 @@ import { getLanguage, checkPythonInstallation } from './actions';
 import Results from './components/Results';
 import ResultScreen from './components/result/ResultScreen';
 import Executions from './components/Executions';
+import Visualizations from './components/Visualizations';
 
 export class App extends Component {
   state = { height: 0 };
@@ -101,6 +103,7 @@ export class App extends Component {
                 component={EditAlgorithm}
               />
               <Route exact path={ADD_ALGORITHM_PATH} component={AddAlgorithm} />
+              <Route exact path={VISUALIZATIONS_PATH} component={Visualizations} />
             </Switch>
           </div>
         </Router>

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -364,6 +364,11 @@ exports[`<App /> renders correctly 1`] = `
           exact={true}
           path="/add-algorithm"
         />
+        <Route
+          component={[Function]}
+          exact={true}
+          path="/visualizations"
+        />
       </Switch>
     </div>
   </HashRouter>

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -111,6 +111,11 @@ exports[`<App /> renders correctly 1`] = `
           "light": "#81c784",
           "main": "#4caf50",
         },
+        "tertiary": Object {
+          "dark": "#8884d8",
+          "light": "#8884d8",
+          "main": "#8884d8",
+        },
         "text": Object {
           "disabled": "rgba(0, 0, 0, 0.38)",
           "hint": "rgba(0, 0, 0, 0.38)",

--- a/src/components/Visualizations.js
+++ b/src/components/Visualizations.js
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { makeStyles } from '@material-ui/core/styles';
+import { useTranslation } from 'react-i18next';
+import Alert from '@material-ui/lab/Alert';
+import Main from './common/Main';
+import AddVisualizationForm from './charts/AddVisualizationForm';
+import ChartsLayout from './charts/ChartsLayout';
+import { getDatasets, getDataset } from '../actions';
+
+const useStyles = makeStyles((theme) => ({
+  infoAlert: {
+    margin: theme.spacing(2),
+  },
+}));
+
+const Visualizations = () => {
+  // i18next, material-ui, and react-redux hooks
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const dispatch = useDispatch();
+
+  // initialize component state holding the selected dataset to be visualized
+  const [selectedDatasetId, setSelectedDatasetId] = useState('');
+
+  // on component load, dispatch getDatasets action
+  useEffect(() => {
+    dispatch(getDatasets);
+  }, [dispatch]);
+
+  // retrieve datasets from redux store
+  // (note: react-redux useSelector roughly equivalent to mapStateToProps)
+  const datasets = useSelector((state) => state.dataset.get('datasets'));
+  // retrieve selected dataset's content from redux store
+  const retrievedDatasetContent = useSelector((state) =>
+    state.dataset.getIn(['current', 'content']).get('content'),
+  );
+
+  // function triggered when 'Visualize' button is clicked
+  const fetchDatasetToBeVisualized = () => {
+    dispatch(getDataset({ id: selectedDatasetId }));
+  };
+
+  if (!datasets.size) {
+    return (
+      <Main>
+        <Alert severity="info" className={classes.infoAlert}>
+          {t('Load a dataset first!')}
+        </Alert>
+      </Main>
+    );
+  }
+
+  return (
+    <Main>
+      <AddVisualizationForm
+        selectedDatasetId={selectedDatasetId}
+        setSelectedDatasetId={setSelectedDatasetId}
+        fetchDatasetToBeVisualized={fetchDatasetToBeVisualized}
+        datasets={datasets}
+      />
+      <ChartsLayout retrievedDatasetContent={retrievedDatasetContent} />
+    </Main>
+  );
+};
+
+export default Visualizations;

--- a/src/components/Visualizations.js
+++ b/src/components/Visualizations.js
@@ -25,7 +25,7 @@ const Visualizations = () => {
 
   // on component load, dispatch getDatasets action
   useEffect(() => {
-    dispatch(getDatasets);
+    dispatch(getDatasets());
   }, [dispatch]);
 
   // retrieve datasets from redux store

--- a/src/components/charts/ActionsByDayChart.js
+++ b/src/components/charts/ActionsByDayChart.js
@@ -19,77 +19,88 @@ import {
   filterActionsByUser,
   findYAxisMax,
 } from '../../utils/charts';
-import { CONTAINER_HEIGHT } from '../../config/constants';
+import { TICK_FONT_SIZE, CONTAINER_HEIGHT } from '../../config/constants';
 
-const useStyles = makeStyles(() => ({
-  typography: { textAlign: 'center' },
+const useStyles = makeStyles((theme) => ({
+  typography: { textAlign: 'center', marginTop: theme.spacing(4) },
+  chart: { marginTop: 30, marginRight: 20, marginBottom: 20, marginLeft: 20 },
 }));
 
 const ActionsByDayChart = ({
   actions,
   allUsersConsolidated,
   usersToFilter,
+  setError,
 }) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const classes = useStyles();
 
-  // actionsByDay is the object passed, after formatting, to the BarChart component below
-  // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
-  // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
-  // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
-  // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
-  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
-  // therefore, to avoid confusion: when all users are selected, show all actions
-  let actionsByDay;
-  if (
-    usersToFilter === null ||
-    usersToFilter.length === 0 ||
-    usersToFilter.length === allUsersConsolidated.length
-  ) {
-    actionsByDay = getActionsByDay(actions);
-  } else {
-    actionsByDay = getActionsByDay(filterActionsByUser(actions, usersToFilter));
-  }
+  try {
+    // actionsByDay is the object passed, after formatting, to the BarChart component below
+    // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
+    // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
+    // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
+    // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+    // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+    // therefore, to avoid confusion: when all users are selected, show all actions
+    let actionsByDay;
+    if (
+      usersToFilter === null ||
+      usersToFilter.length === 0 ||
+      usersToFilter.length === allUsersConsolidated.length
+    ) {
+      actionsByDay = getActionsByDay(actions);
+    } else {
+      actionsByDay = getActionsByDay(
+        filterActionsByUser(actions, usersToFilter),
+      );
+    }
 
-  const yAxisMax = findYAxisMax(actionsByDay);
-  const formattedActionsByDay = formatActionsByDay(actionsByDay);
+    const yAxisMax = findYAxisMax(actionsByDay);
+    const formattedActionsByDay = formatActionsByDay(actionsByDay);
 
-  // if selected user(s) have no actions, render component with message that there are no actions
-  if (formattedActionsByDay.length === 0) {
+    // if selected user(s) have no actions, render component with message that there are no actions
+    if (formattedActionsByDay.length === 0) {
+      return (
+        <EmptyChart
+          usersToFilter={usersToFilter}
+          chartTitle={t('Actions by Day')}
+        />
+      );
+    }
+
     return (
-      <EmptyChart
-        usersToFilter={usersToFilter}
-        chartTitle={t('Actions by Day')}
-      />
+      <>
+        <Typography variant="subtitle1" className={classes.typography}>
+          {t('Actions by Day')}
+        </Typography>
+        <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
+          <BarChart data={formattedActionsByDay} className={classes.chart}>
+            <CartesianGrid strokeDasharray="2" />
+            <XAxis dataKey="date" tick={{ fontSize: TICK_FONT_SIZE }} />
+            <YAxis tick={{ fontSize: TICK_FONT_SIZE }} domain={[0, yAxisMax]} />
+            <Tooltip />
+            <Bar
+              dataKey="count"
+              name="Count"
+              fill={theme.palette.primary.main}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </>
     );
+  } catch (err) {
+    setError(err);
+    return null;
   }
-
-  return (
-    <>
-      <Typography variant="subtitle1" className={classes.typography}>
-        {t('Actions by Day')}
-      </Typography>
-      <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
-        <BarChart
-          data={formattedActionsByDay}
-          margin={{ top: 30, bottom: 20, left: 20, right: 20 }}
-        >
-          <CartesianGrid strokeDasharray="2" />
-          <XAxis dataKey="date" tick={{ fontSize: 14 }} />
-          <YAxis tick={{ fontSize: 14 }} domain={[0, yAxisMax]} />
-          <Tooltip />
-          <Bar dataKey="count" name="Count" fill={theme.palette.primary.main} />
-        </BarChart>
-      </ResponsiveContainer>
-    </>
-  );
 };
 
 ActionsByDayChart.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.object).isRequired,
   allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
   usersToFilter: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setError: PropTypes.func.isRequired,
 };
 
 export default ActionsByDayChart;

--- a/src/components/charts/ActionsByDayChart.js
+++ b/src/components/charts/ActionsByDayChart.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import {
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Bar,
+  ResponsiveContainer,
+} from 'recharts';
+import EmptyChart from './EmptyChart';
+import {
+  getActionsByDay,
+  formatActionsByDay,
+  filterActionsByUser,
+  findYAxisMax,
+} from '../../utils/charts';
+import { CONTAINER_HEIGHT } from '../../config/constants';
+
+const useStyles = makeStyles(() => ({
+  typography: { textAlign: 'center' },
+}));
+
+const ActionsByDayChart = ({
+  actions,
+  allUsersConsolidated,
+  usersToFilter,
+}) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const classes = useStyles();
+
+  // actionsByDay is the object passed, after formatting, to the BarChart component below
+  // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
+  // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
+  // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
+  // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+  // therefore, to avoid confusion: when all users are selected, show all actions
+  let actionsByDay;
+  if (
+    usersToFilter === null ||
+    usersToFilter.length === 0 ||
+    usersToFilter.length === allUsersConsolidated.length
+  ) {
+    actionsByDay = getActionsByDay(actions);
+  } else {
+    actionsByDay = getActionsByDay(filterActionsByUser(actions, usersToFilter));
+  }
+
+  const yAxisMax = findYAxisMax(actionsByDay);
+  const formattedActionsByDay = formatActionsByDay(actionsByDay);
+
+  // if selected user(s) have no actions, render component with message that there are no actions
+  if (formattedActionsByDay.length === 0) {
+    return (
+      <EmptyChart
+        usersToFilter={usersToFilter}
+        chartTitle={t('Actions by Day')}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Typography variant="subtitle1" className={classes.typography}>
+        {t('Actions by Day')}
+      </Typography>
+      <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
+        <BarChart
+          data={formattedActionsByDay}
+          margin={{ top: 30, bottom: 20, left: 20, right: 20 }}
+        >
+          <CartesianGrid strokeDasharray="2" />
+          <XAxis dataKey="date" tick={{ fontSize: 14 }} />
+          <YAxis tick={{ fontSize: 14 }} domain={[0, yAxisMax]} />
+          <Tooltip />
+          <Bar dataKey="count" name="Count" fill={theme.palette.primary.main} />
+        </BarChart>
+      </ResponsiveContainer>
+    </>
+  );
+};
+
+ActionsByDayChart.propTypes = {
+  actions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
+  usersToFilter: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default ActionsByDayChart;

--- a/src/components/charts/ActionsByDayChart.js
+++ b/src/components/charts/ActionsByDayChart.js
@@ -23,7 +23,12 @@ import { TICK_FONT_SIZE, CONTAINER_HEIGHT } from '../../config/constants';
 
 const useStyles = makeStyles((theme) => ({
   typography: { textAlign: 'center', marginTop: theme.spacing(4) },
-  chart: { marginTop: 30, marginRight: 20, marginBottom: 20, marginLeft: 20 },
+  chart: {
+    marginTop: theme.spacing(3.75),
+    marginRight: theme.spacing(2.5),
+    marginBottom: theme.spacing(2.5),
+    marginLeft: theme.spacing(2.5),
+  },
 }));
 
 const ActionsByDayChart = ({

--- a/src/components/charts/ActionsByTimeOfDayChart.js
+++ b/src/components/charts/ActionsByTimeOfDayChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import {
   BarChart,
@@ -20,82 +20,95 @@ import {
   filterActionsByUser,
   findYAxisMax,
 } from '../../utils/charts';
-import { CONTAINER_HEIGHT } from '../../config/constants';
+import { TICK_FONT_SIZE, CONTAINER_HEIGHT } from '../../config/constants';
 
-const useStyles = makeStyles(() => ({
-  typography: { textAlign: 'center' },
+const useStyles = makeStyles((theme) => ({
+  typography: { textAlign: 'center', marginTop: theme.spacing(4) },
+  chart: { marginTop: 30, marginRight: 20, marginBottom: 20, marginLeft: 20 },
 }));
 
 const ActionsByTimeOfDayChart = ({
   actions,
   allUsersConsolidated,
   usersToFilter,
+  setError,
 }) => {
   const { t } = useTranslation();
+  const theme = useTheme();
   const classes = useStyles();
 
-  // actionsByTimeOfDay is the object passed, after formatting, to the BarChart component below
-  // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
-  // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
-  // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
-  // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
-  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
-  // therefore, to avoid confusion: when all users are selected, show all actions
-  let actionsByTimeOfDay;
-  if (
-    usersToFilter === null ||
-    usersToFilter.length === 0 ||
-    usersToFilter.length === allUsersConsolidated.length
-  ) {
-    actionsByTimeOfDay = getActionsByTimeOfDay(actions);
-  } else {
-    actionsByTimeOfDay = getActionsByTimeOfDay(
-      filterActionsByUser(actions, usersToFilter),
+  try {
+    // actionsByTimeOfDay is the object passed, after formatting, to the BarChart component below
+    // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
+    // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
+    // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
+    // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+    // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+    // therefore, to avoid confusion: when all users are selected, show all actions
+    let actionsByTimeOfDay;
+    if (
+      usersToFilter === null ||
+      usersToFilter.length === 0 ||
+      usersToFilter.length === allUsersConsolidated.length
+    ) {
+      actionsByTimeOfDay = getActionsByTimeOfDay(actions);
+    } else {
+      actionsByTimeOfDay = getActionsByTimeOfDay(
+        filterActionsByUser(actions, usersToFilter),
+      );
+    }
+
+    const yAxisMax = findYAxisMax(actionsByTimeOfDay);
+    const formattedActionsByTimeOfDay = formatActionsByTimeOfDay(
+      actionsByTimeOfDay,
     );
-  }
 
-  const yAxisMax = findYAxisMax(actionsByTimeOfDay);
-  const formattedActionsByTimeOfDay = formatActionsByTimeOfDay(
-    actionsByTimeOfDay,
-  );
+    // if selected user(s) have no actions, render component with message that there are no actions
+    if (
+      formattedActionsByTimeOfDay.every((timePeriod) => timePeriod.count === 0)
+    ) {
+      return (
+        <EmptyChart
+          usersToFilter={usersToFilter}
+          chartTitle={t('Actions by Time of Day')}
+        />
+      );
+    }
 
-  // if selected user(s) have no actions, render component with message that there are no actions
-  if (
-    formattedActionsByTimeOfDay.every((timePeriod) => timePeriod.count === 0)
-  ) {
     return (
-      <EmptyChart
-        usersToFilter={usersToFilter}
-        chartTitle={t('Actions by Time of Day')}
-      />
+      <>
+        <Typography variant="subtitle1" className={classes.typography}>
+          {t('Actions by Time of Day')}
+        </Typography>
+        <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
+          <BarChart
+            data={formattedActionsByTimeOfDay}
+            className={classes.chart}
+          >
+            <CartesianGrid strokeDasharray="2" />
+            <XAxis dataKey="timeOfDay" tick={{ fontSize: TICK_FONT_SIZE }} />
+            <YAxis tick={{ fontSize: TICK_FONT_SIZE }} domain={[0, yAxisMax]} />
+            <Tooltip content={<CustomTooltip />} />
+            <Bar
+              dataKey="count"
+              name="Count"
+              fill={theme.palette.tertiary.main}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </>
     );
+  } catch (err) {
+    setError(err);
+    return null;
   }
-
-  return (
-    <>
-      <Typography variant="subtitle1" className={classes.typography}>
-        {t('Actions by Time of Day')}
-      </Typography>
-      <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
-        <BarChart
-          data={formattedActionsByTimeOfDay}
-          margin={{ top: 30, bottom: 20, left: 20, right: 20 }}
-        >
-          <CartesianGrid strokeDasharray="2" />
-          <XAxis dataKey="timeOfDay" tick={{ fontSize: 14 }} />
-          <YAxis tick={{ fontSize: 14 }} domain={[0, yAxisMax]} />
-          <Tooltip content={<CustomTooltip />} />
-          <Bar dataKey="count" name="Count" fill="#8884d8" />
-        </BarChart>
-      </ResponsiveContainer>
-    </>
-  );
 };
 
 ActionsByTimeOfDayChart.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.object).isRequired,
   allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
   usersToFilter: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setError: PropTypes.func.isRequired,
 };
 
 export default ActionsByTimeOfDayChart;

--- a/src/components/charts/ActionsByTimeOfDayChart.js
+++ b/src/components/charts/ActionsByTimeOfDayChart.js
@@ -24,7 +24,12 @@ import { TICK_FONT_SIZE, CONTAINER_HEIGHT } from '../../config/constants';
 
 const useStyles = makeStyles((theme) => ({
   typography: { textAlign: 'center', marginTop: theme.spacing(4) },
-  chart: { marginTop: 30, marginRight: 20, marginBottom: 20, marginLeft: 20 },
+  chart: {
+    marginTop: theme.spacing(3.75),
+    marginRight: theme.spacing(2.5),
+    marginBottom: theme.spacing(2.5),
+    marginLeft: theme.spacing(2.5),
+  },
 }));
 
 const ActionsByTimeOfDayChart = ({

--- a/src/components/charts/ActionsByTimeOfDayChart.js
+++ b/src/components/charts/ActionsByTimeOfDayChart.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import {
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Bar,
+  ResponsiveContainer,
+} from 'recharts';
+import EmptyChart from './EmptyChart';
+import CustomTooltip from './custom/CustomTooltip';
+import {
+  getActionsByTimeOfDay,
+  formatActionsByTimeOfDay,
+  filterActionsByUser,
+  findYAxisMax,
+} from '../../utils/charts';
+import { CONTAINER_HEIGHT } from '../../config/constants';
+
+const useStyles = makeStyles(() => ({
+  typography: { textAlign: 'center' },
+}));
+
+const ActionsByTimeOfDayChart = ({
+  actions,
+  allUsersConsolidated,
+  usersToFilter,
+}) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  // actionsByTimeOfDay is the object passed, after formatting, to the BarChart component below
+  // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
+  // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
+  // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
+  // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+  // therefore, to avoid confusion: when all users are selected, show all actions
+  let actionsByTimeOfDay;
+  if (
+    usersToFilter === null ||
+    usersToFilter.length === 0 ||
+    usersToFilter.length === allUsersConsolidated.length
+  ) {
+    actionsByTimeOfDay = getActionsByTimeOfDay(actions);
+  } else {
+    actionsByTimeOfDay = getActionsByTimeOfDay(
+      filterActionsByUser(actions, usersToFilter),
+    );
+  }
+
+  const yAxisMax = findYAxisMax(actionsByTimeOfDay);
+  const formattedActionsByTimeOfDay = formatActionsByTimeOfDay(
+    actionsByTimeOfDay,
+  );
+
+  // if selected user(s) have no actions, render component with message that there are no actions
+  if (
+    formattedActionsByTimeOfDay.every((timePeriod) => timePeriod.count === 0)
+  ) {
+    return (
+      <EmptyChart
+        usersToFilter={usersToFilter}
+        chartTitle={t('Actions by Time of Day')}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Typography variant="subtitle1" className={classes.typography}>
+        {t('Actions by Time of Day')}
+      </Typography>
+      <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
+        <BarChart
+          data={formattedActionsByTimeOfDay}
+          margin={{ top: 30, bottom: 20, left: 20, right: 20 }}
+        >
+          <CartesianGrid strokeDasharray="2" />
+          <XAxis dataKey="timeOfDay" tick={{ fontSize: 14 }} />
+          <YAxis tick={{ fontSize: 14 }} domain={[0, yAxisMax]} />
+          <Tooltip content={<CustomTooltip />} />
+          <Bar dataKey="count" name="Count" fill="#8884d8" />
+        </BarChart>
+      </ResponsiveContainer>
+    </>
+  );
+};
+
+ActionsByTimeOfDayChart.propTypes = {
+  actions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
+  usersToFilter: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default ActionsByTimeOfDayChart;

--- a/src/components/charts/ActionsByVerbChart.js
+++ b/src/components/charts/ActionsByVerbChart.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import { ResponsiveContainer, PieChart, Pie, Tooltip, Cell } from 'recharts';
+import EmptyChart from './EmptyChart';
+import {
+  getActionsByVerb,
+  filterActionsByUser,
+  formatActionsByVerb,
+} from '../../utils/charts';
+import { COLORS, CONTAINER_HEIGHT } from '../../config/constants';
+
+const useStyles = makeStyles(() => ({
+  typography: { textAlign: 'center' },
+}));
+
+const ActionsByVerbChart = ({
+  actions,
+  allUsersConsolidated,
+  usersToFilter,
+}) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  // actionsByVerb is the object passed, after formatting, to the PieChart component below
+  // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
+  // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
+  // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
+  // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+  // therefore, to avoid confusion: when all users are selected, show all actions
+  let actionsByVerb;
+  if (
+    usersToFilter === null ||
+    usersToFilter.length === 0 ||
+    usersToFilter.length === allUsersConsolidated.length
+  ) {
+    actionsByVerb = getActionsByVerb(actions);
+  } else {
+    actionsByVerb = getActionsByVerb(
+      filterActionsByUser(actions, usersToFilter),
+    );
+  }
+  const formattedActionsByVerb = formatActionsByVerb(actionsByVerb);
+
+  // if selected user(s) have no actions, render component with message that there are no actions
+  if (formattedActionsByVerb.length === 0) {
+    return (
+      <EmptyChart
+        usersToFilter={usersToFilter}
+        chartTitle={t('Actions by Verb')}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Typography variant="subtitle1" className={classes.typography}>
+        {t('Actions by Verb')}
+      </Typography>
+      <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
+        <PieChart fontSize={14}>
+          <Pie
+            data={formattedActionsByVerb}
+            dataKey="percentage"
+            nameKey="verb"
+            fill="#82ca9d"
+            unit="%"
+            label={({ value }) => `${value}%`}
+          >
+            {formattedActionsByVerb.map((entry, index) => (
+              <Cell key={entry.verb} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip formatter={(value) => `${value}%`} />
+        </PieChart>
+      </ResponsiveContainer>
+    </>
+  );
+};
+
+ActionsByVerbChart.propTypes = {
+  actions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
+  usersToFilter: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default ActionsByVerbChart;

--- a/src/components/charts/ActionsByVerbChart.js
+++ b/src/components/charts/ActionsByVerbChart.js
@@ -12,79 +12,85 @@ import {
 } from '../../utils/charts';
 import { COLORS, CONTAINER_HEIGHT } from '../../config/constants';
 
-const useStyles = makeStyles(() => ({
-  typography: { textAlign: 'center' },
+const useStyles = makeStyles((theme) => ({
+  typography: { textAlign: 'center', marginTop: theme.spacing(4) },
 }));
 
 const ActionsByVerbChart = ({
   actions,
   allUsersConsolidated,
   usersToFilter,
+  setError,
 }) => {
   const { t } = useTranslation();
   const classes = useStyles();
 
-  // actionsByVerb is the object passed, after formatting, to the PieChart component below
-  // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
-  // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
-  // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
-  // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
-  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
-  // therefore, to avoid confusion: when all users are selected, show all actions
-  let actionsByVerb;
-  if (
-    usersToFilter === null ||
-    usersToFilter.length === 0 ||
-    usersToFilter.length === allUsersConsolidated.length
-  ) {
-    actionsByVerb = getActionsByVerb(actions);
-  } else {
-    actionsByVerb = getActionsByVerb(
-      filterActionsByUser(actions, usersToFilter),
-    );
-  }
-  const formattedActionsByVerb = formatActionsByVerb(actionsByVerb);
+  try {
+    // actionsByVerb is the object passed, after formatting, to the PieChart component below
+    // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
+    // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
+    // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
+    // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+    // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+    // therefore, to avoid confusion: when all users are selected, show all actions
+    let actionsByVerb;
+    if (
+      usersToFilter === null ||
+      usersToFilter.length === 0 ||
+      usersToFilter.length === allUsersConsolidated.length
+    ) {
+      actionsByVerb = getActionsByVerb(actions);
+    } else {
+      actionsByVerb = getActionsByVerb(
+        filterActionsByUser(actions, usersToFilter),
+      );
+    }
+    const formattedActionsByVerb = formatActionsByVerb(actionsByVerb);
 
-  // if selected user(s) have no actions, render component with message that there are no actions
-  if (formattedActionsByVerb.length === 0) {
+    // if selected user(s) have no actions, render component with message that there are no actions
+    if (formattedActionsByVerb.length === 0) {
+      return (
+        <EmptyChart
+          usersToFilter={usersToFilter}
+          chartTitle={t('Actions by Verb')}
+        />
+      );
+    }
+
     return (
-      <EmptyChart
-        usersToFilter={usersToFilter}
-        chartTitle={t('Actions by Verb')}
-      />
+      <>
+        <Typography variant="subtitle1" className={classes.typography}>
+          {t('Actions by Verb')}
+        </Typography>
+        <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
+          <PieChart fontSize={14}>
+            <Pie
+              data={formattedActionsByVerb}
+              dataKey="percentage"
+              nameKey="verb"
+              unit="%"
+              label={({ value }) => `${value}%`}
+            >
+              {formattedActionsByVerb.map((entry, index) => (
+                <Cell key={entry.verb} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip formatter={(value) => `${value}%`} />
+          </PieChart>
+        </ResponsiveContainer>
+      </>
     );
+  } catch (err) {
+    setError(err);
+    return null;
   }
-
-  return (
-    <>
-      <Typography variant="subtitle1" className={classes.typography}>
-        {t('Actions by Verb')}
-      </Typography>
-      <ResponsiveContainer width="95%" height={CONTAINER_HEIGHT}>
-        <PieChart fontSize={14}>
-          <Pie
-            data={formattedActionsByVerb}
-            dataKey="percentage"
-            nameKey="verb"
-            fill="#82ca9d"
-            unit="%"
-            label={({ value }) => `${value}%`}
-          >
-            {formattedActionsByVerb.map((entry, index) => (
-              <Cell key={entry.verb} fill={COLORS[index % COLORS.length]} />
-            ))}
-          </Pie>
-          <Tooltip formatter={(value) => `${value}%`} />
-        </PieChart>
-      </ResponsiveContainer>
-    </>
-  );
 };
 
 ActionsByVerbChart.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.object).isRequired,
   allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
   usersToFilter: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setError: PropTypes.func.isRequired,
 };
 
 export default ActionsByVerbChart;

--- a/src/components/charts/ActionsMap.js
+++ b/src/components/charts/ActionsMap.js
@@ -35,8 +35,8 @@ const useStyles = makeStyles((theme) => ({
   mapContainer: {
     width: '100%',
     height: 400,
-    marginTop: 30,
-    marginBottom: 30,
+    marginTop: theme.spacing(3.75),
+    marginBottom: theme.spacing(3.75),
   },
 }));
 

--- a/src/components/charts/ActionsMap.js
+++ b/src/components/charts/ActionsMap.js
@@ -1,0 +1,180 @@
+import React, { useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Container from '@material-ui/core/Container';
+import Typography from '@material-ui/core/Typography';
+import { useTranslation } from 'react-i18next';
+import GoogleMapReact from 'google-map-react';
+import useSupercluster from 'use-supercluster';
+import { filterActionsByUser } from '../../utils/charts';
+import {
+  DEFAULT_LATITUDE,
+  DEFAULT_LONGITUDE,
+  DEFAULT_ZOOM,
+  MAX_CLUSTER_ZOOM,
+  CLUSTER_RADIUS,
+  ENTER_KEY_CODE,
+} from '../../config/constants';
+
+const useStyles = makeStyles((theme) => ({
+  clusterMarker: {
+    color: '#fff',
+    background: theme.palette.primary.main,
+    borderRadius: '50%',
+    padding: 12,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    cursor: 'pointer',
+    fontSize: '0.5rem',
+  },
+  typography: {
+    textAlign: 'center',
+  },
+  mapContainer: {
+    width: '100%',
+    height: 400,
+    marginTop: 30,
+    marginBottom: 30,
+  },
+}));
+
+const Marker = ({ children }) => children;
+
+const ActionsMap = ({ actions, allUsersConsolidated, usersToFilter }) => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+  const mapRef = useRef();
+  const [bounds, setBounds] = useState(null);
+  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+
+  // actionsToChart is the array converted to GeoJSON Feature objects below
+  // (1) if you remove all names in the react-select dropdown, usersToFilter becomes null; in this case, show all actions
+  // (2) if no users are selected (i.e. usersToFilter.length === 0), show all actions
+  // (3) if all users are selected (i.e. usersToFilter.length === allUsers.length), also show all actions
+  // #3 above is necessary: some actions are made by users NOT in the users list (e.g. user account deleted)
+  // e.g. we retrieve 100 total actions and 10 users, but these 10 users have only made 90 actions
+  // therefore, to avoid confusion: when all users are selected, show all actions
+  let actionsToChart;
+  if (
+    usersToFilter === null ||
+    usersToFilter.length === 0 ||
+    usersToFilter.length === allUsersConsolidated.length
+  ) {
+    actionsToChart = actions;
+  } else {
+    actionsToChart = filterActionsByUser(actions, usersToFilter);
+  }
+
+  // GeoJSON Feature objects
+  const points = actionsToChart
+    .filter((action) => action.geolocation)
+    .map((action) => ({
+      type: 'Feature',
+      properties: { cluster: false, actionId: action._id },
+      geometry: {
+        type: 'Point',
+        coordinates: [action.geolocation.ll[1], action.geolocation.ll[0]],
+      },
+    }));
+
+  const { clusters } = useSupercluster({
+    points,
+    bounds,
+    zoom,
+    options: { radius: CLUSTER_RADIUS, maxZoom: MAX_CLUSTER_ZOOM },
+  });
+
+  const calculateClusterRadius = (
+    clusterCount,
+    totalCount,
+    baseRadius,
+    scalar,
+  ) => {
+    return baseRadius + (clusterCount / totalCount) * scalar;
+  };
+
+  const handleClusterZoom = (longitude, latitude) => {
+    mapRef.current.setZoom(mapRef.current.zoom + 1);
+    mapRef.current.panTo({ lng: longitude, lat: latitude });
+  };
+
+  return (
+    <>
+      <Typography variant="subtitle1" className={classes.typography}>
+        {t('Actions by Location')}
+      </Typography>
+      <Container className={classes.mapContainer}>
+        <GoogleMapReact
+          bootstrapURLKeys={{ key: process.env.REACT_APP_GOOGLE_KEY }}
+          defaultCenter={{ lat: DEFAULT_LATITUDE, lng: DEFAULT_LONGITUDE }}
+          defaultZoom={DEFAULT_ZOOM}
+          distanceToMouse={() => {}}
+          yesIWantToUseGoogleMapApiInternals
+          onGoogleApiLoaded={({ map }) => {
+            mapRef.current = map;
+          }}
+          onChange={(map) => {
+            setZoom(map.zoom);
+            setBounds([
+              map.bounds.nw.lng,
+              map.bounds.se.lat,
+              map.bounds.se.lng,
+              map.bounds.nw.lat,
+            ]);
+          }}
+        >
+          {clusters.map((cluster) => {
+            const [longitude, latitude] = cluster.geometry.coordinates;
+            const {
+              cluster: isCluster,
+              point_count: pointCount,
+            } = cluster.properties;
+            if (isCluster) {
+              return (
+                <Marker key={cluster.id} lat={latitude} lng={longitude}>
+                  <div
+                    className={classes.clusterMarker}
+                    style={{
+                      width: `${calculateClusterRadius(
+                        pointCount,
+                        points.length,
+                        10,
+                        20,
+                      )}px`,
+                      height: `${calculateClusterRadius(
+                        pointCount,
+                        points.length,
+                        10,
+                        20,
+                      )}px`,
+                    }}
+                    onClick={() => handleClusterZoom(longitude, latitude)}
+                    onKeyPress={(event) => {
+                      if (event.keyCode === ENTER_KEY_CODE) {
+                        handleClusterZoom(longitude, latitude);
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    {pointCount}
+                  </div>
+                </Marker>
+              );
+            }
+            return null;
+          })}
+        </GoogleMapReact>
+      </Container>
+    </>
+  );
+};
+
+ActionsMap.propTypes = {
+  actions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
+  usersToFilter: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default ActionsMap;

--- a/src/components/charts/ActionsMap.js
+++ b/src/components/charts/ActionsMap.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
     color: '#fff',
     background: theme.palette.primary.main,
     borderRadius: '50%',
-    padding: 12,
+    padding: theme.spacing(1.5),
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
@@ -30,6 +30,7 @@ const useStyles = makeStyles((theme) => ({
   },
   typography: {
     textAlign: 'center',
+    marginTop: theme.spacing(4),
   },
   mapContainer: {
     width: '100%',
@@ -85,6 +86,8 @@ const ActionsMap = ({ actions, allUsersConsolidated, usersToFilter }) => {
     options: { radius: CLUSTER_RADIUS, maxZoom: MAX_CLUSTER_ZOOM },
   });
 
+  // function used to calculate size (in px) of clusters drawn on the map
+  // based on total count of points in a cluster divided by total point count
   const calculateClusterRadius = (
     clusterCount,
     totalCount,

--- a/src/components/charts/AddVisualizationForm.js
+++ b/src/components/charts/AddVisualizationForm.js
@@ -27,9 +27,6 @@ const useStyles = makeStyles((theme) => ({
     padding: 0,
     width: '300px',
   },
-  inputLabel: {
-    backgroundColor: '#F7F7F7',
-  },
 }));
 
 const AddVisualizationForm = ({
@@ -49,9 +46,7 @@ const AddVisualizationForm = ({
           className={classes.formControl}
           margin="dense"
         >
-          <InputLabel id="dataset-select" className={classes.inputLabel}>
-            {t('Dataset')}
-          </InputLabel>
+          <InputLabel id="dataset-select">{t('Dataset')}</InputLabel>
           <Select
             labelId="dataset-select"
             value={selectedDatasetId}

--- a/src/components/charts/AddVisualizationForm.js
+++ b/src/components/charts/AddVisualizationForm.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import { useTranslation } from 'react-i18next';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import Button from '@material-ui/core/Button';
+import { List } from 'immutable';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: 'flex',
+    justifyContent: 'center',
+    margin: theme.spacing(2),
+  },
+  subcontainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  formControl: {
+    margin: theme.spacing(1),
+    width: '100%',
+  },
+  select: {
+    padding: 0,
+    width: '300px',
+  },
+  inputLabel: {
+    backgroundColor: '#F7F7F7',
+  },
+}));
+
+const AddVisualizationForm = ({
+  selectedDatasetId,
+  setSelectedDatasetId,
+  fetchDatasetToBeVisualized,
+  datasets,
+}) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <div className={classes.subcontainer}>
+        <FormControl
+          variant="outlined"
+          className={classes.formControl}
+          margin="dense"
+        >
+          <InputLabel id="dataset-select" className={classes.inputLabel}>
+            {t('Dataset')}
+          </InputLabel>
+          <Select
+            labelId="dataset-select"
+            value={selectedDatasetId}
+            onChange={(e) => setSelectedDatasetId(e.target.value)}
+            label={t('Dataset')}
+            className={classes.select}
+          >
+            {datasets.map(({ id, name }) => (
+              <MenuItem value={id} key={id}>
+                {name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <div>
+          <Button
+            variant="contained"
+            color="primary"
+            disabled={!selectedDatasetId}
+            onClick={fetchDatasetToBeVisualized}
+          >
+            {t('Visualize')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+AddVisualizationForm.propTypes = {
+  selectedDatasetId: PropTypes.string.isRequired,
+  setSelectedDatasetId: PropTypes.func.isRequired,
+  fetchDatasetToBeVisualized: PropTypes.func.isRequired,
+  datasets: PropTypes.instanceOf(List).isRequired,
+};
+
+export default AddVisualizationForm;

--- a/src/components/charts/ChartsLayout.js
+++ b/src/components/charts/ChartsLayout.js
@@ -1,4 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { useTranslation } from 'react-i18next';
+import Alert from '@material-ui/lab/Alert';
 import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
 import UsersSelect from './UsersSelect';
@@ -13,60 +16,102 @@ import {
   addValueKeyToUsers,
 } from '../../utils/charts';
 
+const useStyles = makeStyles((theme) => ({
+  infoAlert: {
+    margin: theme.spacing(2),
+  },
+}));
+
 const ChartsLayout = ({ retrievedDatasetContent }) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  const [datasetContent, setDatasetContent] = useState();
   const [usersToFilter, setUsersToFilter] = useState([]);
-  if (!retrievedDatasetContent) {
+  const [error, setError] = useState();
+
+  useEffect(() => {
+    setDatasetContent(retrievedDatasetContent);
+    setError();
+  }, [retrievedDatasetContent]);
+
+  if (!datasetContent) {
     return null;
   }
 
-  const dataInJson = JSON.parse(retrievedDatasetContent);
-  const { data } = dataInJson;
-  const { actions, users } = data;
+  if (error) {
+    return (
+      <Alert severity="error" className={classes.infoAlert}>
+        {t('There was an error visualizing this dataset.')}
+      </Alert>
+    );
+  }
 
-  const allUsersConsolidated = addValueKeyToUsers(
-    formatConsolidatedUsers(
-      consolidateUsers(removeLearningAnalyticsUser(users)),
-    ),
-  );
+  try {
+    const dataInJson = JSON.parse(datasetContent);
+    const { data } = dataInJson;
+    const { actions, users } = data;
 
-  return (
-    <div>
-      <UsersSelect
-        allUsersConsolidated={allUsersConsolidated}
-        setUsersToFilter={setUsersToFilter}
-      />
-      <Grid container>
-        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
-          <ActionsByDayChart
-            actions={actions}
-            allUsersConsolidated={allUsersConsolidated}
-            usersToFilter={usersToFilter}
-          />
+    if (!actions.length) {
+      return (
+        <Alert severity="warning" className={classes.infoAlert}>
+          {t('This dataset does not contain any actions.')}
+        </Alert>
+      );
+    }
+
+    const allUsersConsolidated = addValueKeyToUsers(
+      formatConsolidatedUsers(
+        consolidateUsers(removeLearningAnalyticsUser(users)),
+      ),
+    );
+
+    return (
+      <div>
+        <UsersSelect
+          allUsersConsolidated={allUsersConsolidated}
+          setUsersToFilter={setUsersToFilter}
+        />
+        <Grid container>
+          <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+            <ActionsByDayChart
+              actions={actions}
+              allUsersConsolidated={allUsersConsolidated}
+              usersToFilter={usersToFilter}
+              setError={setError}
+            />
+          </Grid>
+          <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+            <ActionsMap
+              actions={actions}
+              allUsersConsolidated={allUsersConsolidated}
+              usersToFilter={usersToFilter}
+              setError={setError}
+            />
+          </Grid>
+          <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+            <ActionsByTimeOfDayChart
+              actions={actions}
+              allUsersConsolidated={allUsersConsolidated}
+              usersToFilter={usersToFilter}
+              setError={setError}
+            />
+          </Grid>
+          <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+            <ActionsByVerbChart
+              actions={actions}
+              allUsersConsolidated={allUsersConsolidated}
+              usersToFilter={usersToFilter}
+              setError={setError}
+            />
+          </Grid>
         </Grid>
-        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
-          <ActionsMap
-            actions={actions}
-            allUsersConsolidated={allUsersConsolidated}
-            usersToFilter={usersToFilter}
-          />
-        </Grid>
-        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
-          <ActionsByTimeOfDayChart
-            actions={actions}
-            allUsersConsolidated={allUsersConsolidated}
-            usersToFilter={usersToFilter}
-          />
-        </Grid>
-        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
-          <ActionsByVerbChart
-            actions={actions}
-            allUsersConsolidated={allUsersConsolidated}
-            usersToFilter={usersToFilter}
-          />
-        </Grid>
-      </Grid>
-    </div>
-  );
+      </div>
+    );
+  } catch (err) {
+    setError(err);
+    return null;
+  }
 };
 
 ChartsLayout.propTypes = {

--- a/src/components/charts/ChartsLayout.js
+++ b/src/components/charts/ChartsLayout.js
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Grid from '@material-ui/core/Grid';
+import UsersSelect from './UsersSelect';
+import ActionsByDayChart from './ActionsByDayChart';
+import ActionsMap from './ActionsMap';
+import ActionsByTimeOfDayChart from './ActionsByTimeOfDayChart';
+import ActionsByVerbChart from './ActionsByVerbChart';
+import {
+  removeLearningAnalyticsUser,
+  consolidateUsers,
+  formatConsolidatedUsers,
+  addValueKeyToUsers,
+} from '../../utils/charts';
+
+const ChartsLayout = ({ retrievedDatasetContent }) => {
+  const [usersToFilter, setUsersToFilter] = useState([]);
+  if (!retrievedDatasetContent) {
+    return null;
+  }
+
+  const dataInJson = JSON.parse(retrievedDatasetContent);
+  const { data } = dataInJson;
+  const { actions, users } = data;
+
+  const allUsersConsolidated = addValueKeyToUsers(
+    formatConsolidatedUsers(
+      consolidateUsers(removeLearningAnalyticsUser(users)),
+    ),
+  );
+
+  return (
+    <div>
+      <UsersSelect
+        allUsersConsolidated={allUsersConsolidated}
+        setUsersToFilter={setUsersToFilter}
+      />
+      <Grid container>
+        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+          <ActionsByDayChart
+            actions={actions}
+            allUsersConsolidated={allUsersConsolidated}
+            usersToFilter={usersToFilter}
+          />
+        </Grid>
+        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+          <ActionsMap
+            actions={actions}
+            allUsersConsolidated={allUsersConsolidated}
+            usersToFilter={usersToFilter}
+          />
+        </Grid>
+        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+          <ActionsByTimeOfDayChart
+            actions={actions}
+            allUsersConsolidated={allUsersConsolidated}
+            usersToFilter={usersToFilter}
+          />
+        </Grid>
+        <Grid item xs={12} sm={12} md={6} lg={6} xl={6}>
+          <ActionsByVerbChart
+            actions={actions}
+            allUsersConsolidated={allUsersConsolidated}
+            usersToFilter={usersToFilter}
+          />
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+ChartsLayout.propTypes = {
+  retrievedDatasetContent: PropTypes.string.isRequired,
+};
+
+export default ChartsLayout;

--- a/src/components/charts/EmptyChart.js
+++ b/src/components/charts/EmptyChart.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import { CONTAINER_HEIGHT } from '../../config/constants';
+
+const useStyles = makeStyles(() => ({
+  typography: { textAlign: 'center' },
+  emptyChartAlert: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: `${CONTAINER_HEIGHT}px`,
+  },
+}));
+
+const EmptyChart = ({ usersToFilter, chartTitle }) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  let message = '';
+  if (usersToFilter.length > 1) {
+    message = t('No actions to show for these users');
+  } else {
+    message = t('No actions to show for this user');
+  }
+
+  return (
+    <>
+      <Typography variant="subtitle1" className={classes.typography}>
+        {chartTitle}
+      </Typography>
+      <div className={classes.emptyChartAlert}>
+        <Typography>{message}</Typography>
+      </div>
+    </>
+  );
+};
+
+EmptyChart.propTypes = {
+  usersToFilter: PropTypes.arrayOf(
+    PropTypes.shape({
+      ids: PropTypes.arrayOf(PropTypes.string),
+      name: PropTypes.string,
+      type: PropTypes.string,
+      value: PropTypes.string,
+    }),
+  ).isRequired,
+  chartTitle: PropTypes.string.isRequired,
+};
+
+export default EmptyChart;

--- a/src/components/charts/EmptyChart.js
+++ b/src/components/charts/EmptyChart.js
@@ -5,8 +5,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import { CONTAINER_HEIGHT } from '../../config/constants';
 
-const useStyles = makeStyles(() => ({
-  typography: { textAlign: 'center' },
+const useStyles = makeStyles((theme) => ({
+  typography: { textAlign: 'center', marginTop: theme.spacing(4) },
   emptyChartAlert: {
     display: 'flex',
     justifyContent: 'center',

--- a/src/components/charts/UsersSelect.js
+++ b/src/components/charts/UsersSelect.js
@@ -8,7 +8,6 @@ import CustomValueContainer from './custom/CustomValueContainer';
 const useStyles = makeStyles((theme) => ({
   container: {
     marginRight: theme.spacing(3),
-    marginBottom: theme.spacing(4),
     display: 'flex',
     justifyContent: 'flex-end',
     alignItems: 'center',
@@ -65,7 +64,7 @@ const UsersSelect = ({ allUsersConsolidated, setUsersToFilter }) => {
         hideSelectedOptions={false}
         allowSelectAll
         getOptionLabel={(option) => option.name}
-        placeholder="Filter by user..."
+        placeholder={t('Filter by user...')}
         value={selectedUsers}
         onChange={(selected) => {
           if (

--- a/src/components/charts/UsersSelect.js
+++ b/src/components/charts/UsersSelect.js
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import Select from 'react-select';
+import { makeStyles } from '@material-ui/core/styles';
+import CustomValueContainer from './custom/CustomValueContainer';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    marginRight: theme.spacing(3),
+    marginBottom: theme.spacing(4),
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+}));
+
+// custom styling used by react-select (deviates from material-ui approach used in rest of app)
+const styleConstants = {
+  border: 'solid 1px #dfe3e9',
+  borderRadius: '4px',
+  fontSize: '0.8rem',
+};
+
+const customStyles = {
+  menu: () => ({
+    width: '250px',
+    position: 'absolute',
+    zIndex: 999999,
+    backgroundColor: '#F7F7F7',
+    ...styleConstants,
+  }),
+  control: () => ({
+    display: 'flex',
+    minWidth: '250px',
+    maxWidth: '600px',
+    backgroundColor: '#F7F7F7',
+    ...styleConstants,
+  }),
+};
+
+const UsersSelect = ({ allUsersConsolidated, setUsersToFilter }) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const [selectedUsers, setSelectedUsers] = useState([]);
+
+  // custom option allowing us to select all users in the dropdown
+  const allOption = {
+    name: t('Select All'),
+    value: '*',
+  };
+
+  const handleChange = (selectedUser) => {
+    setSelectedUsers(selectedUser);
+    setUsersToFilter(selectedUser);
+  };
+
+  return (
+    <div className={classes.container}>
+      <Select
+        styles={customStyles}
+        options={[allOption, ...allUsersConsolidated]}
+        isMulti
+        closeMenuOnSelect={false}
+        hideSelectedOptions={false}
+        allowSelectAll
+        getOptionLabel={(option) => option.name}
+        placeholder="Filter by user..."
+        value={selectedUsers}
+        onChange={(selected) => {
+          if (
+            selected !== null &&
+            selected.length > 0 &&
+            selected[selected.length - 1].value === allOption.value
+          ) {
+            return handleChange(allUsersConsolidated);
+          }
+          return handleChange(selected);
+        }}
+        components={{
+          ValueContainer: CustomValueContainer,
+        }}
+      />
+    </div>
+  );
+};
+
+UsersSelect.propTypes = {
+  allUsersConsolidated: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setUsersToFilter: PropTypes.func.isRequired,
+};
+
+export default UsersSelect;

--- a/src/components/charts/custom/CustomTooltip.js
+++ b/src/components/charts/custom/CustomTooltip.js
@@ -1,0 +1,66 @@
+// CustomToolTip used in ActionsByTimeOfDayChart
+// x-axis labels in that chart say 'morning', 'afternoon', etc.
+// this tooltip adds the time of day those labels refer to
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import {
+  LATE_NIGHT,
+  EARLY_MORNING,
+  MORNING,
+  AFTERNOON,
+  EVENING,
+  NIGHT,
+} from '../../../config/constants';
+
+const useStyles = makeStyles((theme) => ({
+  customTooltipDiv: {
+    backgroundColor: 'white',
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    border: '0.5px solid #cccccc',
+  },
+  customTooltipCount: {
+    color: theme.palette.primary.main,
+  },
+}));
+
+const CustomTooltip = ({ active, payload, label }) => {
+  const classes = useStyles();
+
+  const generateAddedTooltipText = (input) => {
+    switch (input) {
+      case LATE_NIGHT:
+        return '00:00-04:00';
+      case EARLY_MORNING:
+        return '04:00-08:00';
+      case MORNING:
+        return '08:00-12:00';
+      case AFTERNOON:
+        return '12:00-16:00';
+      case EVENING:
+        return '16:00-20:00';
+      case NIGHT:
+        return '20:00-00:00';
+      default:
+        return null;
+    }
+  };
+
+  if (active) {
+    return (
+      <div className={classes.customTooltipDiv}>
+        <p>{`${label} (${generateAddedTooltipText(label)})`}</p>
+        <p className={classes.customTooltipCount}>
+          {`Count : ${payload[0].value}`}
+        </p>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default CustomTooltip;

--- a/src/components/charts/custom/CustomValueContainer.js
+++ b/src/components/charts/custom/CustomValueContainer.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { components } from 'react-select';
+
+// this component, used within the UsersSelect component, overrides react-select's default text display
+// by default, react-select will keep expanding its text display as additional options are selected
+// with this component, after 2 selections, the text box will stop expanding and display: 'A, B, and X other(s) selected'
+// eslint-disable-next-line react/prop-types
+const CustomValueContainer = ({ children, ...props }) => {
+  const { t } = useTranslation();
+
+  // values is an array of objects corresponding to the currently made selection
+  let [values] = children;
+
+  if (Array.isArray(values)) {
+    const { length } = values;
+    const plural = length === 3 ? '' : 's';
+    const alsoSelectedCount = length - 2;
+    if (length === 1) {
+      values = `${values[0].key}`;
+    } else if (length === 2) {
+      values = `${values[0].key}, ${values[1].key}`;
+    } else {
+      const firstSelection = values[0].key;
+      const secondSelection = values[1].key;
+      values = t('Many users selected...', {
+        firstSelection,
+        secondSelection,
+        alsoSelectedCount,
+        plural,
+      });
+    }
+  }
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <components.ValueContainer {...props}>
+      {values}
+      {children[1]}
+    </components.ValueContainer>
+  );
+};
+
+export default CustomValueContainer;

--- a/src/components/charts/custom/CustomValueContainer.js
+++ b/src/components/charts/custom/CustomValueContainer.js
@@ -14,7 +14,6 @@ const CustomValueContainer = ({ children, ...props }) => {
 
   if (Array.isArray(values)) {
     const { length } = values;
-    const plural = length === 3 ? '' : 's';
     const alsoSelectedCount = length - 2;
     if (length === 1) {
       values = `${values[0].key}`;
@@ -26,8 +25,7 @@ const CustomValueContainer = ({ children, ...props }) => {
       values = t('Many users selected...', {
         firstSelection,
         secondSelection,
-        alsoSelectedCount,
-        plural,
+        count: alsoSelectedCount,
       });
     }
   }

--- a/src/components/common/MainMenu.js
+++ b/src/components/common/MainMenu.js
@@ -9,6 +9,7 @@ import PieChartIcon from '@material-ui/icons/PieChart';
 import CloseIcon from '@material-ui/icons/ExitToApp';
 import AssessmentIcon from '@material-ui/icons/Assessment';
 import CodeIcon from '@material-ui/icons/Code';
+import TimelineIcon from '@material-ui/icons/Timeline';
 import TuneIcon from '@material-ui/icons/Tune';
 import { withTranslation } from 'react-i18next';
 import {
@@ -18,12 +19,14 @@ import {
   DEVELOPER_PATH,
   RESULTS_PATH,
   EXECUTIONS_PATH,
+  VISUALIZATIONS_PATH,
 } from '../../config/paths';
 import {
   ALGORITHMS_MENU_ITEM_ID,
   DATASETS_MENU_ITEM_ID,
   QUIT_MENU_ITEM_ID,
   EXECUTIONS_MENU_ITEM_ID,
+  VISUALIZATIONS_MENU_ITEM_ID,
 } from '../../config/selectors';
 
 export class MainMenu extends Component {
@@ -89,6 +92,26 @@ export class MainMenu extends Component {
     return null;
   };
 
+  renderVisualizations = () => {
+    const {
+      match: { path },
+      t,
+    } = this.props;
+    return (
+      <MenuItem
+        id={VISUALIZATIONS_MENU_ITEM_ID}
+        onClick={() => this.handleClick(VISUALIZATIONS_PATH)}
+        selected={path === VISUALIZATIONS_PATH}
+        button
+      >
+        <ListItemIcon>
+          <TimelineIcon />
+        </ListItemIcon>
+        <ListItemText primary={t('Visualizations')} />
+      </MenuItem>
+    );
+  };
+
   render() {
     const {
       match: { path },
@@ -139,8 +162,8 @@ export class MainMenu extends Component {
           </ListItemIcon>
           <ListItemText primary={t('Results')} />
         </MenuItem>
+        {this.renderVisualizations()}
         {this.renderDeveloperItem()}
-
         {this.renderCloseApp()}
       </List>
     );

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -91,3 +91,6 @@ export const COLORS = [
   '#B54A3F',
   '#FFFFAF',
 ];
+
+// used to define yaxis and xaxis tick sizes in ActionsByDayChart and ActionsByTimeOfDayChart
+export const TICK_FONT_SIZE = 14;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -38,3 +38,56 @@ export const ADD_OPTIONS = {
   FILE: 'file',
   EDITOR: 'editor',
 };
+
+// Default latitude and longitude for centering map in ActionsMap.js. Zurich coordinates used below.
+export const DEFAULT_LATITUDE = 47.3769;
+export const DEFAULT_LONGITUDE = 8.5417;
+
+// Default Zoom for map in ActionsMap.js
+export const DEFAULT_ZOOM = 3;
+
+// If user zooms in beyond MAX_CLUSTER_ZOOM, map no longer displays data points.
+// Maximum possible value is 16 (zoomed all the way in). See npm supercluster docs for further info.
+export const MAX_CLUSTER_ZOOM = 12;
+
+// Size (in pixels) of cluster zones used by supercluster.
+// The higher CLUSTER_RADIUS, the more map area absorbed into a single cluster.
+export const CLUSTER_RADIUS = 75;
+
+// Key code for the Enter/Return key (Used in a placeholder keyboard event listener in ActionsMap)
+export const ENTER_KEY_CODE = 13;
+
+// height of container in ActionsByDayChart, ActionsByTimeOfDayChart, ActionsByVerbChart
+export const CONTAINER_HEIGHT = 450;
+
+// strings used in components/charts/custom/CustomTooltip to generate added tooltip text in ActionsByTimeOfDayChart
+export const LATE_NIGHT = 'Late night';
+export const EARLY_MORNING = 'Early morning';
+export const MORNING = 'Morning';
+export const AFTERNOON = 'Afternoon';
+export const EVENING = 'Evening';
+export const NIGHT = 'Night';
+
+// Used in /utils/charts.js, to filter out the auto-generated 'user' with name 'Learning Analytics'
+export const LEARNING_ANALYTICS_USER_ID = '5405e202da3a95cf9050e8f9';
+
+// Used in /utils/charts.js and then the ActionsByVerb piechart
+// for visual purposes, all verbs with < 3 percent of total actions are consolidated into an entry 'other'
+export const MIN_PERCENTAGE_TO_SHOW_VERB = 3;
+
+// 'other' verb used in /utils/charts.js
+export const OTHER_VERB = 'Other';
+
+// colors used to fill the segments of the ActionsByVerb piechart
+export const COLORS = [
+  '#3066BE',
+  '#96CCE6',
+  '#20A39E',
+  '#61D095',
+  '#FFBA49',
+  '#EF5B5B',
+  '#FFA8A8',
+  '#A4036F',
+  '#B54A3F',
+  '#FFFFAF',
+];

--- a/src/config/paths.js
+++ b/src/config/paths.js
@@ -10,6 +10,7 @@ export const SETTINGS_PATH = '/settings';
 export const RESULTS_PATH = '/results';
 export const RESULT_PATH = '/result/:id';
 export const EXECUTIONS_PATH = '/executions';
+export const VISUALIZATIONS_PATH = '/visualizations';
 
 export const buildDatasetPath = (id = ':id') => {
   return `/dataset/${id}`;

--- a/src/config/selectors.js
+++ b/src/config/selectors.js
@@ -30,3 +30,4 @@ export const DATASET_TABLE_SUBSPACE_COUNT_ID = 'datasetTableSubspaceCount';
 export const DATASET_TABLE_ACTION_COUNT_ID = 'datasetTableActionCount';
 export const DATASET_TABLE_USER_COUNT_ID = 'datasetTableUserCount';
 export const DATASET_TABLE_COUNTRY_COUNT_ID = 'datasetTableCountryCount';
+export const VISUALIZATIONS_MENU_ITEM_ID = 'visualizationsMenuItem';

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -85,7 +85,8 @@
     "Actions by Verb": "Actions by Verb",
     "Actions by Time of Day": "Actions by Time of Day",
     "Actions by Day": "Actions by Day",
-    "Many users selected...": "{{firstSelection}}, {{secondSelection}}, and {{alsoSelectedCount}} other{{plural}} selected",
+    "Many users selected...": "{{firstSelection}}, {{secondSelection}}, and {{count}} other selected",
+    "Many users selected..._plural": "{{firstSelection}}, {{secondSelection}}, and {{count}} others selected",
     "There was an error visualizing this dataset.": "There was an error visualizing this dataset.",
     "This dataset does not contain any actions.": "This dataset does not contain any actions."
   }

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -43,7 +43,7 @@
     "Delete algorithm": "Delete algorithm",
     "Dataset": "Dataset",
     "Algorithm": "Algorithm",
-    "Load a dataset first": "Load a dataset first",
+    "Load a dataset first!": "Load a dataset first!",
     "No algorithms are available": "No algorithms are available",
     "Execute": "Execute",
     "Executions": "Executions",
@@ -75,6 +75,18 @@
     "An unexpected error happened while opening the algorithm.": "An unexpected error happened while opening the algorithm.",
     "Editing algorithm": "Editing algorithm",
     "your code goes here": "your code goes here",
-    "You are modifying a Graasp algorithm. Saving will create a new file instead.": "You are modifying a Graasp algorithm. Saving will create a new file instead."
+    "You are modifying a Graasp algorithm. Saving will create a new file instead.": "You are modifying a Graasp algorithm. Saving will create a new file instead.",
+    "Select All": "Select All",
+    "Filter by user...": "Filter by user...",
+    "No actions to show for these users": "No actions to show for these users",
+    "No actions to show for this user": "No actions to show for this user",
+    "Visualize": "Visualize",
+    "Actions by Location": "Actions by Location",
+    "Actions by Verb": "Actions by Verb",
+    "Actions by Time of Day": "Actions by Time of Day",
+    "Actions by Day": "Actions by Day",
+    "Many users selected...": "{{firstSelection}}, {{secondSelection}}, and {{alsoSelectedCount}} other{{plural}} selected",
+    "There was an error visualizing this dataset.": "There was an error visualizing this dataset.",
+    "This dataset does not contain any actions.": "This dataset does not contain any actions."
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -43,7 +43,7 @@
     "Delete algorithm": "Supprimer l'algorithme",
     "Dataset": "Dataset",
     "Algorithm": "Algorithme",
-    "Load a dataset first": "Veuillez importer un dataset",
+    "Load a dataset first!": "Veuillez importer un dataset!",
     "No algorithms are available": "Aucun algorithme n'est disponible",
     "Execute": "Exécuter",
     "Executions": "Exécutions",
@@ -74,6 +74,18 @@
     "Save": "Enregistrer",
     "An unexpected error happened while opening the algorithm.": "Une erreur s'est produite lors de l'ouverture de l'algorithme.",
     "your code goes here": "écrivez votre code ici",
-    "You are modifying a Graasp algorithm. Saving will create a new file instead.": "Vous modifiez un algorithme de Graasp. L'enregistrer créera un nouveau fichier."
+    "You are modifying a Graasp algorithm. Saving will create a new file instead.": "Vous modifiez un algorithme de Graasp. L'enregistrer créera un nouveau fichier.",
+    "Select All": "",
+    "Filter by user...": "",
+    "No actions to show for these users": "",
+    "No actions to show for this user": "",
+    "Visualize": "Visualiser",
+    "Actions by Location": "",
+    "Actions by Verb": "",
+    "Actions by Time of Day": "",
+    "Actions by Day": "",
+    "Many users selected...": "{{firstSelection}}, {{secondSelection}}, et {{alsoSelectedCount}} autre{{plural}}...",
+    "There was an error visualizing this dataset.": "",
+    "This dataset does not contain any actions.": ""
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -84,8 +84,9 @@
     "Actions by Verb": "Actions par verbe",
     "Actions by Time of Day": "Actions par moment de la journée",
     "Actions by Day": "Actions par jour",
-    "Many users selected...": "{{firstSelection}}, {{secondSelection}}, et {{alsoSelectedCount}} autre{{plural}}...",
-    "There was an error visualizing this dataset.": "Une erreur s'est produise en visualisant ce dataset",
+    "Many users selected...": "{{firstSelection}}, {{secondSelection}}, et un autre...",
+    "Many users selected..._plural": "{{firstSelection}}, {{secondSelection}}, et {{count}} autres...",
+    "There was an error visualizing this dataset.": "Une erreur s'est produite en visualisant ce dataset",
     "This dataset does not contain any actions.": "Ce dataset ne contient aucune action"
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -75,17 +75,17 @@
     "An unexpected error happened while opening the algorithm.": "Une erreur s'est produite lors de l'ouverture de l'algorithme.",
     "your code goes here": "écrivez votre code ici",
     "You are modifying a Graasp algorithm. Saving will create a new file instead.": "Vous modifiez un algorithme de Graasp. L'enregistrer créera un nouveau fichier.",
-    "Select All": "",
-    "Filter by user...": "",
-    "No actions to show for these users": "",
-    "No actions to show for this user": "",
+    "Select All": "Tout sélectionner",
+    "Filter by user...": "Trier par utilisateur...",
+    "No actions to show for these users": "Aucune action à afficher pour ces utilisateurs",
+    "No actions to show for this user": "Aucune action à afficher pour cet utilisateur",
     "Visualize": "Visualiser",
-    "Actions by Location": "",
-    "Actions by Verb": "",
-    "Actions by Time of Day": "",
-    "Actions by Day": "",
+    "Actions by Location": "Actions par localisation",
+    "Actions by Verb": "Actions par verbe",
+    "Actions by Time of Day": "Actions par moment de la journée",
+    "Actions by Day": "Actions par jour",
     "Many users selected...": "{{firstSelection}}, {{secondSelection}}, et {{alsoSelectedCount}} autre{{plural}}...",
-    "There was an error visualizing this dataset.": "",
-    "This dataset does not contain any actions.": ""
+    "There was an error visualizing this dataset.": "Une erreur s'est produise en visualisant ce dataset",
+    "This dataset does not contain any actions.": "Ce dataset ne contient aucune action"
   }
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -7,6 +7,7 @@ const theme = createMuiTheme({
   palette: {
     primary: { light: '#5050d2', main: '#5050d2', dark: '#5050d2' },
     secondary: { light: '#ffffff', main: '#ffffff', dark: '#ffffff' },
+    tertiary: { light: '#8884d8', main: '#8884d8', dark: '#8884d8' },
   },
 });
 

--- a/src/utils/charts.js
+++ b/src/utils/charts.js
@@ -113,18 +113,32 @@ export const formatActionsByTimeOfDay = (actionsByTimeOfDayObject) => {
 
 // Takes array of action objects and returns an object with {key: value} pairs of {verb: %-of-actions}
 export const getActionsByVerb = (actions) => {
-  const totalActions = actions.length;
-  const actionsByVerb = {};
+  const totalActionsCount = actions.length;
+  const actionsByVerbCount = {};
   actions.forEach((action) => {
-    if (!actionsByVerb[action.verb]) {
-      // if verb is still not in the actionsByVerb object, add it and assign it to (1 / totalActions)
-      // we use (1 / totalActions) because in the end we want this object to be {verb: PERCENTAGE-of-total-actions}
-      actionsByVerb[action.verb] = 1 / totalActions;
+    if (!actionsByVerbCount[action.verb]) {
+      // if verb is still not in the actionsByVerbCount object, add it and initialize it to 1
+      actionsByVerbCount[action.verb] = 1;
+      // else increment existing count
     } else {
-      actionsByVerb[action.verb] += 1 / totalActions;
+      actionsByVerbCount[action.verb] += 1;
     }
   });
-  return actionsByVerb;
+
+  // we want to return an object with key-value pairs of {verb: PERCENTAGE-of-total-actions}
+  // therefore need to convert count of actions to a percentage
+  // (1) convert actionsByVerbCount to an array of 2d arrays with [verb, count] via Object.entries
+  // (2) map onto [verb, count / totalActionsCount]
+  // (3) convert back into an object via Object.fromEntries
+  const actionsByVerbCountArray = Object.entries(actionsByVerbCount);
+  const actionsByVerbPercentageArray = actionsByVerbCountArray.map(
+    ([verb, count]) => [verb, count / totalActionsCount],
+  );
+  const actionsByVerbPercentage = Object.fromEntries(
+    actionsByVerbPercentageArray,
+  );
+
+  return actionsByVerbPercentage;
 };
 
 export const formatActionsByVerb = (actionsByVerbObject) => {
@@ -136,7 +150,7 @@ export const formatActionsByVerb = (actionsByVerbObject) => {
       _.capitalize(verb),
       parseFloat((ratio * 100).toFixed(2)),
     ])
-    .filter(([entry]) => entry[1] >= MIN_PERCENTAGE_TO_SHOW_VERB);
+    .filter((entry) => entry[1] >= MIN_PERCENTAGE_TO_SHOW_VERB);
 
   // add ['other', x%] to cover all verbs that are filtered out of the array
   if (formattedActionsByVerbArray.length) {
@@ -156,12 +170,10 @@ export const formatActionsByVerb = (actionsByVerbObject) => {
   }
 
   // convert to recharts required format
-  return formattedActionsByVerbArray.map(([verb, percentage]) => {
-    return {
-      verb,
-      percentage,
-    };
-  });
+  return formattedActionsByVerbArray.map(([verb, percentage]) => ({
+    verb,
+    percentage,
+  }));
 };
 
 // 'usersArray' has the form [ { ids: [1, 2], name: 'Augie March', type: 'light', value: 'Augie March'}, {...}, ... ]

--- a/src/utils/charts.js
+++ b/src/utils/charts.js
@@ -1,0 +1,241 @@
+const _ = require('lodash');
+const {
+  LEARNING_ANALYTICS_USER_ID,
+  MIN_PERCENTAGE_TO_SHOW_VERB,
+  OTHER_VERB,
+  LATE_NIGHT,
+  EARLY_MORNING,
+  MORNING,
+  AFTERNOON,
+  EVENING,
+  NIGHT,
+} = require('../config/constants');
+
+// Takes array of action objects and returns an object with {key: value} pairs of {date: #-of-actions}
+export const getActionsByDay = (actions) => {
+  const actionsByDay = {};
+  actions.forEach((action) => {
+    const actionDate = new Date(action.createdAt.slice(0, 10));
+    if (!actionsByDay[actionDate]) {
+      actionsByDay[actionDate] = 1;
+    } else {
+      actionsByDay[actionDate] += 1;
+    }
+  });
+  return actionsByDay;
+};
+
+// Takes object with {key: value} pairs of {date: #-of-actions} and returns a date-sorted array in Recharts.js format
+export const formatActionsByDay = (actionsByDayObject) => {
+  const actionsByDayArray = Object.entries(actionsByDayObject);
+  const sortedActionsByDay = actionsByDayArray.sort(
+    (entryA, entryB) => Date.parse(entryA[0]) - Date.parse(entryB[0]),
+  );
+  return sortedActionsByDay.map((entry) => {
+    const entryDate = new Date(entry[0]);
+    return {
+      date: `${entryDate.getDate()}-${
+        entryDate.getMonth() + 1
+      }-${entryDate.getFullYear()}`,
+      count: entry[1],
+    };
+  });
+};
+
+// given an actionsByDay object, finds max value to set on the yAxis in the graph in ActionsByDayChart.js
+export const findYAxisMax = (actionsByDay) => {
+  const arrayOfActionsCount = Object.values(actionsByDay);
+  if (!arrayOfActionsCount.length) {
+    return null;
+  }
+  const maxActionsCount = arrayOfActionsCount.reduce((a, b) => Math.max(a, b));
+  let yAxisMax;
+  // if maxActionsCount <= 100, round up yAxisMax to the nearest ten; else, to the nearest hundred
+  if (maxActionsCount <= 100) {
+    yAxisMax = Math.ceil(maxActionsCount / 10) * 10;
+  } else {
+    yAxisMax = Math.ceil(maxActionsCount / 100) * 100;
+  }
+  return yAxisMax;
+};
+
+// helper function used in getActionsByTimeOfDay
+// todo: update this function to retrieve hour of day using JS Date objects/moment
+const getActionHourOfDay = (action) => {
+  // expects action to be an object with a createdAt key
+  // createdAt should have the format "2020-12-31T23:59:59.999Z"
+  return action.createdAt.slice(11, 13);
+};
+
+// Takes array of action objects and returns an object with {key: value} pairs of {hourOfDay: #-of-actions}
+export const getActionsByTimeOfDay = (actions) => {
+  const actionsByTimeOfDay = {
+    [LATE_NIGHT]: 0,
+    [EARLY_MORNING]: 0,
+    [MORNING]: 0,
+    [AFTERNOON]: 0,
+    [EVENING]: 0,
+    [NIGHT]: 0,
+  };
+  actions.forEach((action) => {
+    const actionHourOfDay = getActionHourOfDay(action);
+    if (actionHourOfDay >= 0 && actionHourOfDay < 4) {
+      actionsByTimeOfDay[LATE_NIGHT] += 1;
+    } else if (actionHourOfDay >= 4 && actionHourOfDay < 8) {
+      actionsByTimeOfDay[EARLY_MORNING] += 1;
+    } else if (actionHourOfDay >= 8 && actionHourOfDay < 12) {
+      actionsByTimeOfDay[MORNING] += 1;
+    } else if (actionHourOfDay >= 12 && actionHourOfDay < 16) {
+      actionsByTimeOfDay[AFTERNOON] += 1;
+    } else if (actionHourOfDay >= 16 && actionHourOfDay < 20) {
+      actionsByTimeOfDay[EVENING] += 1;
+    } else if (actionHourOfDay >= 20 && actionHourOfDay < 24) {
+      actionsByTimeOfDay[NIGHT] += 1;
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(`actionHourOfDay ${actionHourOfDay} is undefined`);
+    }
+  });
+  return actionsByTimeOfDay;
+};
+
+// Takes object with {key: value} pairs of {timeOfDay: #-of-actions}
+// returns a date-sorted array in Recharts.js format
+export const formatActionsByTimeOfDay = (actionsByTimeOfDayObject) => {
+  const actionsByTimeOfDayArray = Object.entries(actionsByTimeOfDayObject);
+  return actionsByTimeOfDayArray.map((entry) => {
+    return {
+      timeOfDay: entry[0],
+      count: entry[1],
+    };
+  });
+};
+
+// Takes array of action objects and returns an object with {key: value} pairs of {verb: %-of-actions}
+export const getActionsByVerb = (actions) => {
+  const totalActions = actions.length;
+  const actionsByVerb = {};
+  actions.forEach((action) => {
+    if (!actionsByVerb[action.verb]) {
+      // if verb is still not in the actionsByVerb object, add it and assign it to (1 / totalActions)
+      // we use (1 / totalActions) because in the end we want this object to be {verb: PERCENTAGE-of-total-actions}
+      actionsByVerb[action.verb] = 1 / totalActions;
+    } else {
+      actionsByVerb[action.verb] += 1 / totalActions;
+    }
+  });
+  return actionsByVerb;
+};
+
+export const formatActionsByVerb = (actionsByVerbObject) => {
+  const actionsByVerbArray = Object.entries(actionsByVerbObject);
+
+  // capitalize verbs (entry[0][0]), convert 0.0x notation to x% and round to two decimal places (entry[0][1])
+  const formattedActionsByVerbArray = actionsByVerbArray
+    .map((entry) => [
+      _.capitalize(entry[0]),
+      parseFloat((entry[1] * 100).toFixed(2)),
+    ])
+    .filter((entry) => entry[1] >= MIN_PERCENTAGE_TO_SHOW_VERB);
+
+  // add ['other', x%] to cover all verbs that are filtered out of the array
+  if (formattedActionsByVerbArray.length) {
+    formattedActionsByVerbArray.push([
+      OTHER_VERB,
+      // ensure that it is a number with two decimal places
+      parseFloat(
+        (
+          100 -
+          formattedActionsByVerbArray.reduce(
+            (acc, current) => acc + current[1],
+            0,
+          )
+        ).toFixed(2),
+      ),
+    ]);
+  }
+
+  // convert to recharts required format
+  return formattedActionsByVerbArray.map((entry) => {
+    return {
+      verb: entry[0],
+      percentage: entry[1],
+    };
+  });
+};
+
+// 'usersArray' has the form [ { ids: [1, 2], name: 'Augie March', type: 'light', value: 'Augie March'}, {...}, ... ]
+// i.e. a user (identified by their name) can have multiple ids (due to different sign-in sesions)
+// 'actions' is an array in the format retrieved from the API: [ { id: 1, user: 2, ... }, {...} ]
+// therefore note: id is the id of the action, and user is the userId of the user performing the action
+export const filterActionsByUser = (actions, usersArray) => {
+  return actions.filter((action) => {
+    return usersArray.some((user) => {
+      return user.ids.includes(action.user);
+    });
+  });
+};
+
+// remove user 'Learning Analytics' from users list retrieved by API
+// this is an auto-generated 'user' that we don't want to display in the application
+export const removeLearningAnalyticsUser = (usersArray) => {
+  return usersArray.filter((user) => user._id !== LEARNING_ANALYTICS_USER_ID);
+};
+
+// consolidate users with the same name into a single entry
+// instead of users = [{id: 1, name: 'Augie March'}, {id: 2, name: 'augie march'}], users = [{ids: [1,2], name: 'augie march'}]
+export const consolidateUsers = (usersArray) => {
+  // remove trailing spaces from user names and turn them lower case
+  const usersArrayWithTrimmedNames = usersArray.map((user) => {
+    return { ...user, name: user.name.trim().toLowerCase() };
+  });
+
+  // group ids of matching user names under one object
+  const consolidatedUsersArray = [];
+  usersArrayWithTrimmedNames.forEach((user) => {
+    const userIndex = consolidatedUsersArray.findIndex(
+      (arrayUser) => arrayUser.name === user.name,
+    );
+    // if user doesn't exist in consolidatedUsersArray, push that user into the array
+    if (userIndex === -1) {
+      consolidatedUsersArray.push({
+        ids: [user._id],
+        name: user.name,
+        type: user.type,
+      });
+    }
+    // if user *does* exist in consolidatedUsersArray, push current user's id to that user's ids array
+    else {
+      consolidatedUsersArray[userIndex].ids.push(user._id);
+    }
+  });
+  return consolidatedUsersArray;
+};
+
+// for presentation purposes, format user names, then sort them alphabetically
+// proper names are recapitalized ('Augie March'), and only the first letter of emails is capitalized
+export const formatConsolidatedUsers = (consolidatedUsersArray) => {
+  const usersArrayCapitalized = consolidatedUsersArray.map((user) => {
+    // if user name includes @ symbol, only capitalize first letter
+    if (user.name.indexOf('@') !== -1) {
+      return {
+        ...user,
+        name: _.capitalize(user.name),
+      };
+    }
+    // otherwise, reg exp below capitalizes first letter of each part of a user's space-delimited name
+    return {
+      ...user,
+      name: user.name.replace(/\b(\w)/g, (char) => char.toUpperCase()),
+    };
+  });
+  // return alphbatically sorted array of users
+  return _.sortBy(usersArrayCapitalized, (user) => user.name);
+};
+
+// for react-select purposes, add a 'value' key to each element of the users array, holding the same value as the key 'name'
+export const addValueKeyToUsers = (consolidatedUsersArray) => {
+  return consolidatedUsersArray.map((user) => {
+    return { ...user, value: user.name };
+  });
+};

--- a/src/utils/charts.js
+++ b/src/utils/charts.js
@@ -31,13 +31,13 @@ export const formatActionsByDay = (actionsByDayObject) => {
   const sortedActionsByDay = actionsByDayArray.sort(
     (entryA, entryB) => Date.parse(entryA[0]) - Date.parse(entryB[0]),
   );
-  return sortedActionsByDay.map((entry) => {
-    const entryDate = new Date(entry[0]);
+  return sortedActionsByDay.map(([date, count]) => {
+    const entryDate = new Date(date);
     return {
       date: `${entryDate.getDate()}-${
         entryDate.getMonth() + 1
       }-${entryDate.getFullYear()}`,
-      count: entry[1],
+      count,
     };
   });
 };
@@ -103,10 +103,10 @@ export const getActionsByTimeOfDay = (actions) => {
 // returns a date-sorted array in Recharts.js format
 export const formatActionsByTimeOfDay = (actionsByTimeOfDayObject) => {
   const actionsByTimeOfDayArray = Object.entries(actionsByTimeOfDayObject);
-  return actionsByTimeOfDayArray.map((entry) => {
+  return actionsByTimeOfDayArray.map(([timeOfDay, count]) => {
     return {
-      timeOfDay: entry[0],
-      count: entry[1],
+      timeOfDay,
+      count,
     };
   });
 };
@@ -132,11 +132,11 @@ export const formatActionsByVerb = (actionsByVerbObject) => {
 
   // capitalize verbs (entry[0][0]), convert 0.0x notation to x% and round to two decimal places (entry[0][1])
   const formattedActionsByVerbArray = actionsByVerbArray
-    .map((entry) => [
-      _.capitalize(entry[0]),
-      parseFloat((entry[1] * 100).toFixed(2)),
+    .map(([verb, ratio]) => [
+      _.capitalize(verb),
+      parseFloat((ratio * 100).toFixed(2)),
     ])
-    .filter((entry) => entry[1] >= MIN_PERCENTAGE_TO_SHOW_VERB);
+    .filter(([entry]) => entry[1] >= MIN_PERCENTAGE_TO_SHOW_VERB);
 
   // add ['other', x%] to cover all verbs that are filtered out of the array
   if (formattedActionsByVerbArray.length) {
@@ -156,10 +156,10 @@ export const formatActionsByVerb = (actionsByVerbObject) => {
   }
 
   // convert to recharts required format
-  return formattedActionsByVerbArray.map((entry) => {
+  return formattedActionsByVerbArray.map(([verb, percentage]) => {
     return {
-      verb: entry[0],
-      percentage: entry[1],
+      verb,
+      percentage,
     };
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,6 +203,13 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
+"@babel/helper-module-imports@^7.0.0":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+  dependencies:
+    "@babel/types" "^7.12.5"
+
 "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.8.3":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
@@ -1174,6 +1181,15 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.12.5":
+  version "7.12.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
+  integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1353,10 +1369,87 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
-"@emotion/hash@^0.8.0":
+"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
+  version "10.0.29"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
+  integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
+  dependencies:
+    "@emotion/sheet" "0.9.4"
+    "@emotion/stylis" "0.8.5"
+    "@emotion/utils" "0.11.3"
+    "@emotion/weak-memoize" "0.2.5"
+
+"@emotion/core@^10.0.9":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
+  integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
+"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
+  integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
+  dependencies:
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+    babel-plugin-emotion "^10.0.27"
+
+"@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
+  version "0.11.16"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
+  integrity sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==
+  dependencies:
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/unitless" "0.7.5"
+    "@emotion/utils" "0.11.3"
+    csstype "^2.5.7"
+
+"@emotion/sheet@0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
+  integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/stylis@0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
+"@emotion/unitless@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@0.11.3":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
+  integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
+
+"@emotion/weak-memoize@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+
+"@googlemaps/js-api-loader@^1.7.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.8.0.tgz#7ee2f77da1a84476f8eec61156e858662078711a"
+  integrity sha512-aFxlJVFOC00KELhlaqU6tpnxj9szVdG7OSHxQzc9uhp4Ky8/zvYNnzZg2S+pPvhe+WkJPugQL8fowP5nYTBXUg==
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -1549,6 +1642,11 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@mapbox/point-geometry@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
+  integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
 
 "@material-ui/core@4.11.0":
   version "4.11.0"
@@ -2017,6 +2115,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/use-deep-compare-effect@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/use-deep-compare-effect/-/use-deep-compare-effect-1.2.0.tgz#d55d9bda6fea5ff7c93038c53052db1b3145f5d9"
+  integrity sha512-2uNqaSobMvUTGR7G72tUHDX+Kx341q25OuM0m2B6VID7eljIvYuDaFTKfmDnbvej67yEhCc35zA6dmIYriwOXA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -2937,6 +3042,22 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-emotion@^10.0.27:
+  version "10.0.33"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
+  integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/serialize" "^0.11.16"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
@@ -2954,7 +3075,7 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@2.8.0:
+babel-plugin-macros@2.8.0, babel-plugin-macros@^2.0.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -2967,6 +3088,11 @@ babel-plugin-named-asset-import@^0.3.6:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz#156cd55d3f1228a5765774340937afc8398067dd"
   integrity sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -3027,6 +3153,11 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
+
+balanced-match@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+  integrity sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -3774,7 +3905,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3:
+classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -4313,7 +4444,7 @@ conventional-recommended-bump@6.0.9:
     meow "^7.0.0"
     q "^1.5.1"
 
-convert-source-map@1.7.0, convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.7.0:
+convert-source-map@1.7.0, convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -4370,7 +4501,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -4772,7 +4903,7 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.5.2:
+csstype@^2.5.2, csstype@^2.5.7:
   version "2.6.13"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
@@ -4793,6 +4924,69 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
+d3-format@1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
+  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
+
+d3-interpolate@1, d3-interpolate@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+d3-scale@^2.1.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
+  integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
+  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -4890,6 +5084,11 @@ decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+decimal.js-light@^2.4.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -5013,6 +5212,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+dequal@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -5183,6 +5387,13 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-helpers@^5.0.1:
   version "5.2.0"
@@ -6098,7 +6309,7 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-eventemitter3@^4.0.0:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -6483,6 +6694,11 @@ find-cache-dir@^3.2.0:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -7053,6 +7269,16 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+google-map-react@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/google-map-react/-/google-map-react-2.1.9.tgz#6e539ce8bf28e7b8cda6058402e7581d1d1cec3d"
+  integrity sha512-//Pa0o6sdspU2H0ehVztSDQSnYYeV6TY4Z6ftty34yiCJYLliOzeq17dA9uFkyUFdL+XwbTU6e9mfs+bjBMIzw==
+  dependencies:
+    "@googlemaps/js-api-loader" "^1.7.0"
+    "@mapbox/point-geometry" "^0.1.0"
+    eventemitter3 "^4.0.4"
+    prop-types "^15.7.2"
 
 got@^11.0.2:
   version "11.8.0"
@@ -8965,6 +9191,11 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+kdbush@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
+  integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -9228,6 +9459,11 @@ lodash.curry@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
   integrity sha1-JI42By7ekGUB11lmIAqG2riyMXA=
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -9313,6 +9549,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.union@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
@@ -9328,7 +9569,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@4, lodash@4.17.20, "lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
+lodash@4, lodash@4.17.20, "lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@~4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -9480,6 +9721,11 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
+math-expression-evaluator@^1.2.14:
+  version "1.2.22"
+  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz#c14dcb3d8b4d150e5dcea9c68c8dad80309b0d5e"
+  integrity sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -9512,6 +9758,11 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
+
+memoize-one@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -11689,7 +11940,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -11861,7 +12112,7 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-raf@^3.4.1:
+raf@^3.4.0, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -12012,6 +12263,13 @@ react-i18next@11.7.0:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
+react-input-autosize@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
+  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -12055,6 +12313,16 @@ react-redux@7.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+react-resize-detector@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-2.3.0.tgz#57bad1ae26a28a62a2ddb678ba6ffdf8fa2b599c"
+  integrity sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    prop-types "^15.6.0"
+    resize-observer-polyfill "^1.5.0"
 
 react-router-dom@5.2.0:
   version "5.2.0"
@@ -12145,6 +12413,30 @@ react-scripts@3.4.1:
   optionalDependencies:
     fsevents "2.1.2"
 
+react-select@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
+  integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/cache" "^10.0.9"
+    "@emotion/core" "^10.0.9"
+    "@emotion/css" "^10.0.9"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-input-autosize "^2.2.2"
+    react-transition-group "^4.3.0"
+
+react-smooth@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.5.tgz#94ae161d7951cdd893ccb7099d031d342cb762ad"
+  integrity sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==
+  dependencies:
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-transition-group "^2.5.0"
+
 react-test-renderer@^16.0.0-0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
@@ -12162,7 +12454,17 @@ react-textarea-autosize@^6.1.0:
   dependencies:
     prop-types "^15.6.0"
 
-react-transition-group@^4.4.0:
+react-transition-group@^2.5.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
+  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
+  dependencies:
+    dom-helpers "^3.4.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.3.0, react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
@@ -12331,6 +12633,30 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+recharts-scale@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.4.3.tgz#040b4f638ed687a530357292ecac880578384b59"
+  integrity sha512-t8p5sccG9Blm7c1JQK/ak9O8o95WGhNXD7TXg/BW5bYbVlr6eCeRBNpgyigD4p6pSSMehC5nSvBUPj6F68rbFA==
+  dependencies:
+    decimal.js-light "^2.4.1"
+
+recharts@1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.8.5.tgz#ca94a3395550946334a802e35004ceb2583fdb12"
+  integrity sha512-tM9mprJbXVEBxjM7zHsIy6Cc41oO/pVYqyAsOHLxlJrbNBuLs0PHB3iys2M+RqCF0//k8nJtZF6X6swSkWY3tg==
+  dependencies:
+    classnames "^2.2.5"
+    core-js "^2.6.10"
+    d3-interpolate "^1.3.0"
+    d3-scale "^2.1.0"
+    d3-shape "^1.2.0"
+    lodash "^4.17.5"
+    prop-types "^15.6.0"
+    react-resize-detector "^2.3.0"
+    react-smooth "^1.0.5"
+    recharts-scale "^0.4.2"
+    reduce-css-calc "^1.3.0"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -12368,6 +12694,22 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+reduce-css-calc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
+  integrity sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=
+  dependencies:
+    balanced-match "^0.4.2"
+    math-expression-evaluator "^1.2.14"
+    reduce-function-call "^1.0.1"
+
+reduce-function-call@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.3.tgz#60350f7fb252c0a67eb10fd4694d16909971300f"
+  integrity sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==
+  dependencies:
+    balanced-match "^1.0.0"
 
 redux-devtools-extension@2.13.8:
   version "2.13.8"
@@ -12602,6 +12944,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-alpn@^1.0.0:
   version "1.0.0"
@@ -13281,7 +13628,7 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -13743,6 +14090,13 @@ sumchecker@^3.0.1:
   integrity sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==
   dependencies:
     debug "^4.1.0"
+
+supercluster@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.0.tgz#f0a457426ec0ab95d69c5f03b51e049774b94479"
+  integrity sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==
+  dependencies:
+    kdbush "^3.0.0"
 
 supports-color@7.2.0, supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
@@ -14388,6 +14742,23 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-deep-compare-effect@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.4.0.tgz#3f40e3fa5b0b8d79e4126e83be384ed602472405"
+  integrity sha512-46rF7ULcRnxI4+1Zoul95+KB48hpn1MUH1aXEBMyU+Sh1KJDqrTAkwhnxQL6ydBAqu3gLebYylcr0zpVBzbxxQ==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@types/use-deep-compare-effect" "^1.2.0"
+    dequal "^2.0.2"
+
+use-supercluster@0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/use-supercluster/-/use-supercluster-0.2.9.tgz#40dd9961bf3fa897165d161d532de3d96131cc02"
+  integrity sha512-nHGS/InkCtM0l1oNmy02LwdH2325rIZNgl5eexUStoyjhUJZejVK3WfgaAKJTjRseeipaVtV9GVDgGXIVCn9yw==
+  dependencies:
+    dequal "^2.0.2"
+    use-deep-compare-effect "^1.4.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
these are the same charts found in graasp-research, and look as follows in -insights:

![Screen Shot 2020-11-10 at 3 32 40 PM](https://user-images.githubusercontent.com/19311953/98687656-43724580-236a-11eb-9762-3f58b8b5dec7.png)

a few notes:

1. instead of `mapDispatchToprops` and `mapStateToProps` I used react-redux hooks in the new `Visualizations.js` component
2. you will need to add a `REACT_APP_GOOGLE_KEY=` to `.env.local` for the map to show up without the 'developer' overlay; I can share our key offline
3. a lot of this is adapted/reused from graasp-research (so feedback counts double!)