### PR TITLE
feat: add shuffle algorithm

### DIFF
--- a/public/app/algorithms/shuffle_fields.py
+++ b/public/app/algorithms/shuffle_fields.py
@@ -12,10 +12,7 @@ def shuffle_attribute(array, attribute):
     values = [elem.get(attribute, None) for elem in array]
     true_random.shuffle(values)
     for elem, new_value in zip(array, values):
-        if new_value is not None:
-            elem[attribute] = new_value
-        elif attribute in elem:
-            del attribute[elem]
+        elem[attribute] = new_value
 
 
 def iterate_and_shuffle(dataset, field_selection):

--- a/public/app/algorithms/shuffle_fields.py
+++ b/public/app/algorithms/shuffle_fields.py
@@ -1,0 +1,69 @@
+
+import random
+import json
+
+from graasp_utils import load_dataset, save_dataset, parse_arguments
+
+
+true_random = random.SystemRandom()
+
+
+def shuffle_attribute(array, attribute):
+    values = [elem.get(attribute, None) for elem in array]
+    true_random.shuffle(values)
+    for elem, new_value in zip(array, values):
+        if new_value is not None:
+            elem[attribute] = new_value
+        elif attribute in elem:
+            del attribute[elem]
+
+
+def iterate_and_shuffle(dataset, field_selection):
+    properties = field_selection.get('properties', {})
+
+    # iterate through each property
+    for prop_name, prop_field_sel in properties.items():
+        prop = dataset.get(prop_name, {})
+
+        # if it is an object, iterate through its properties using recursion
+        if prop_field_sel.get('type', '') == 'object':
+            iterate_and_shuffle(prop, prop_field_sel)
+
+        # if it is an array, "items" specifies the array's content
+        elif prop_field_sel.get('type', '') == 'array' and isinstance(prop, list):
+            items = prop_field_sel.get('items', {})
+
+            # if "items" is a list
+            # => 1st element matches with 1st field selection, 2nd elem with 2nd field selection, etc
+            if isinstance(items, list):
+                for item, fs in zip(prop, items):
+                    iterate_and_shuffle(item, fs)
+
+            # if "items" is an object/dict => every element matches the unique field selection
+            elif isinstance(items, dict):
+                sub_properties = items.get('properties', {})
+                selected_attributes = [attribute for attribute, sub_value in sub_properties.items(
+                ) if sub_value.get('selected', False)]
+
+                for attribute in selected_attributes:
+                    shuffle_attribute(prop, attribute)
+
+                for item in prop:
+                    iterate_and_shuffle(item, items)
+
+
+def main():
+    args = parse_arguments([
+        {'name': 'fields', 'type': str}
+    ])
+
+    dataset = load_dataset(args.dataset_path)
+    fields = json.loads(args.fields)
+
+    iterate_and_shuffle(dataset, fields)
+
+    save_dataset(dataset, args.output_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/public/app/config/graaspAlgorithms.js
+++ b/public/app/config/graaspAlgorithms.js
@@ -146,7 +146,8 @@ const GRAASP_ALGORITHMS = [
   {
     id: 'shuffle-fields',
     name: 'Shuffle fields',
-    description: 'Shuffle selected array fields from a dataset',
+    description:
+      "Given an array of objects, this algorithm randomly shuffles the values in selected keys between the array's objects",
     filename: 'shuffle_fields.py',
     author: AUTHORS.GRAASP,
     language: PROGRAMMING_LANGUAGES.PYTHON,

--- a/public/app/config/graaspAlgorithms.js
+++ b/public/app/config/graaspAlgorithms.js
@@ -143,6 +143,40 @@ const GRAASP_ALGORITHMS = [
       },
     ],
   },
+  {
+    id: 'shuffle-fields',
+    name: 'Shuffle fields',
+    description: 'Shuffle selected array fields from a dataset',
+    filename: 'shuffle_fields.py',
+    author: AUTHORS.GRAASP,
+    language: PROGRAMMING_LANGUAGES.PYTHON,
+    type: ALGORITHM_TYPES.ANONYMIZATION,
+    parameters: [
+      {
+        name: 'fields',
+        type: PARAMETER_TYPES.FIELD_SELECTOR,
+        description: 'Select fields to shuffle:',
+        value: {
+          [GRAASP_SCHEMA_ID]: _.merge(generateFieldSelector(GRAASP_SCHEMA), {
+            properties: {
+              data: {
+                properties: {
+                  actions: {
+                    items: {
+                      properties: {
+                        verb: { selected: true },
+                        geolocation: { selected: true },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        },
+      },
+    ],
+  },
 ];
 
 module.exports = GRAASP_ALGORITHMS;

--- a/test/fixtures/datasets/datasets.js
+++ b/test/fixtures/datasets/datasets.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { DATASET_TYPES, SCHEMA_TYPES } from '../../../src/shared/constants';
+import { DATASET_TYPES, GRAASP_SCHEMA_ID } from '../../../src/shared/constants';
 
 // eslint-disable-next-line import/prefer-default-export
 export const SIMPLE_DATASET = {
@@ -33,5 +33,5 @@ export const DATASET_1000_KB = {
   createdAt: Date.now(),
   lastModified: Date.now(),
   type: DATASET_TYPES.SOURCE,
-  schema: SCHEMA_TYPES.GRAASP,
+  schema: GRAASP_SCHEMA_ID,
 };


### PR DESCRIPTION
The shuffle algorithm takes a field selection parameter to select the attributes to shuffle. Although any field can be selected, only the ones that are children to arrays will be shuffled.

two potential flaws:
- The dependencies between the shuffled attributes and the others are broken
- each user has multiple records. So if a shuffled attribute has the same value for every record of a user, an attacker might count the occurrences and link the user back